### PR TITLE
Switch language validation to 'language-tags' pkg

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -20,7 +20,7 @@ import os.path
 import hashlib
 from shutil import copyfile
 from datetime import datetime
-import pycountry
+import language_tags
 import requests
 from lxml import etree
 from github import Github
@@ -201,14 +201,6 @@ class HungarianStyleNotation(base.BaseRule):
 class LanguageCode(base.BaseRule):
     """Check that Text elements have a valid language code."""
 
-    languages = []
-
-    def __init__(self, election_tree, schema_file):
-        super(LanguageCode, self).__init__(election_tree, schema_file)
-        for language in pycountry.languages:
-        	if hasattr(language, 'alpha_2'):
-        		self.languages.append(language.alpha_2)
-
     def elements(self):
         return ["Text"]
 
@@ -216,11 +208,9 @@ class LanguageCode(base.BaseRule):
         if "language" not in element.attrib:
             return
         elem_lang = element.get("language")
-        if (not elem_lang or elem_lang not in self.languages or
-                elem_lang.strip() == ""):
+        if (not elem_lang or elem_lang.strip() == "" or not language_tags.tags.check(elem_lang)):
             raise base.ElectionError(
-                "Line %d. %s is not a valid ISO 639 language code "% (
-                    element.sourceline, elem_lang))
+                "Line %d. %s is not a valid language code" % (element.sourceline, elem_lang))
 
 
 class EmptyText(base.BaseRule):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url='https://github.com/google/election_results_xml_validator',
     install_requires=[
         'lxml>=3.3.4',
-        'pycountry>=17.01.08',
+        'language-tags>=0.4.2',
         '%s>=2.10' % requests_version,
         'pygithub>=1.28'
     ],


### PR DESCRIPTION
Changes LanguageCode validation to, rather than use 'pycountry' to build
a list of just languages, use a package ('language-tags') that implements
BCP 47.  Which might be overkill, but supporting obscure cases won't hurt
anything and this makes it support common cases like "en-US".

"en", as used in the sample files, still works fine.