### PR TITLE
Added 2 new rules - DuplicateContestNames and CheckIdentifiers

### DIFF
--- a/base.py
+++ b/base.py
@@ -246,7 +246,7 @@ class RulesRegistry(SchemaHandler):
                     for exception in self.exceptions[e_type][rule_class]:
                         if exception.error_log:
                             for error in exception.error_log:
-                                print " "*14+" AAAA Line {0}: {1}".format(
+                                print " "*14+" Line {0}: {1}".format(
                                     error.line, error.message)
                         else:
                             print " "*14+"{0}".format(exception)

--- a/base.py
+++ b/base.py
@@ -246,7 +246,7 @@ class RulesRegistry(SchemaHandler):
                     for exception in self.exceptions[e_type][rule_class]:
                         if exception.error_log:
                             for error in exception.error_log:
-                                print " "*14+"Line {0}: {1}".format(
+                                print " "*14+" AAAA Line {0}: {1}".format(
                                     error.line, error.message)
                         else:
                             print " "*14+"{0}".format(exception)


### PR DESCRIPTION
Added 2 classes to rules.py
DuplicateContestNames: To find duplicate contest names and output with error messages.
CheckIdentifiers: Check for stable identifiers for candidates, contests and parties.