### PR TITLE
Bug/ Added new rule "DuplicateContestNames"

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -835,6 +835,37 @@ class CandidateNotReferenced(base.TreeRule):
             raise base.ElectionTreeError(
                 "The Election File contains unreferenced Candidates", error_log)
 
+class DuplicateContestNames(base.TreeRule):
+    """Check that the file contains unique ContestNames.
+        Add Warning if duplicate ContestName found."""
+
+    def check(self):
+        name_contest_id = {}  # Mapping for <Name> and its Contest ObjectId.
+        error_log = []
+        for event, element in etree.iterwalk(self.election_tree):
+            tag = self.strip_schema_ns(element)
+            if tag != "Contest":
+                continue
+            object_id = element.get("objectId", None)
+            name = element.find("Name")
+            if name is None or not name.text:
+                error_message = "Contest {0} is missing a <Name> ".format(
+                    object_id)
+                error_log.append(base.ErrorLogEntry(
+                    element.sourceline, error_message))
+                continue
+            name_contest_id.setdefault(name.text, []).append(object_id)
+            """Add names and its objectId as key and list of values.
+		Ideally 1 objectId. If duplicates are found, then list of multiple objectIds."""
+        for name, contests in name_contest_id.iteritems():
+            if len(contests) > 1:
+                error_message = ("Contest name '{0}' appears in following {1} contests: {2}".format(
+                    name, len(contests), ", ".join(contests)))
+                error_log.append(base.ErrorLogEntry(None, error_message))
+        if error_log:
+            raise base.ElectionTreeError(
+                "The Election File contains duplicate contest names.", error_log)
+
 
 # To add new rules, create a new class, inherit the base rule
 # then add it to this list
@@ -857,7 +888,8 @@ _RULES = [
     ReusedCandidate,
     CoalitionParties,
     ProperBallotSelection,
-    CandidateNotReferenced
+    CandidateNotReferenced,
+    DuplicateContestNames
 ]
 
 


### PR DESCRIPTION
New rule added to rules.py. It gives out error messages for duplicate contest names with the name and line on which it is present in the feed.