### PR TITLE
Add rule GpUnitsTree

### DIFF
--- a/GpUnitsTree_sample_fail.xml
+++ b/GpUnitsTree_sample_fail.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<ElectionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Election>
+    <ElectionScopeId>ru0002</ElectionScopeId>
+    <Name>
+      <Text language="en">2013 Virginia General Election</Text>
+    </Name>
+    <StartDate>2013-11-05</StartDate>
+    <EndDate>2013-11-05</EndDate>
+    <Type>general</Type>
+  </Election>
+  <Format>precinct-level</Format>
+  <GeneratedDate>2013-11-05T14:25:28</GeneratedDate>
+  <GpUnitCollection>
+    <GpUnit objectId="ru0002" xsi:type="ReportingUnit">
+      <ComposingGpUnitIds>ru_pre90111 ru_pre90139 ru_pre90183 ru_temp_id
+      ru_preXXXXX</ComposingGpUnitIds>
+      <ExternalIdentifiers>
+        <ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va</Value>
+        </ExternalIdentifier>
+        <ExternalIdentifier>
+          <Type>fips</Type>
+          <Value>51</Value>
+        </ExternalIdentifier>
+      </ExternalIdentifiers>
+      <Name>Virginia</Name>
+      <ElectionAdministration>
+        <ContactInformation label="ci60000">
+          <AddressLine>Washington Building First Floor</AddressLine>
+          <AddressLine>1100 Bank Street</AddressLine>
+          <AddressLine>Richmond, VA 23219</AddressLine>
+          <Name>State Board of Elections</Name>
+        </ContactInformation>
+      </ElectionAdministration>
+      <Type>state</Type>
+    </GpUnit>
+    <GpUnit objectId="ru0001" xsi:type="ReportingUnit">
+      <ComposingGpUnitIds>ru_pre90111 ru_pre90139 ru_pre90183 ru_pre92426</ComposingGpUnitIds>
+      <ExternalIdentifiers>
+        <ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va/county:albemarle</Value>
+        </ExternalIdentifier>
+        <ExternalIdentifier>
+          <Type>fips</Type>
+          <Value>51003</Value>
+        </ExternalIdentifier>
+      </ExternalIdentifiers>
+      <Name>Albemarle County</Name>
+      <ElectionAdministration>
+        <ContactInformation label="ci60001">
+          <AddressLine>1600 5TH STREET</AddressLine>
+          <AddressLine>CHARLOTTESVILLE, VA 22902</AddressLine>
+          <Name>ALBEMARLE COUNTY VOTER REGISTRATION</Name>
+          <Schedule>
+            <Hours>
+              <StartTime>08:30:00-05:00</StartTime>
+              <EndTime>17:00:00-05:00</EndTime>
+            </Hours>
+          </Schedule>
+        </ContactInformation>
+        <ElectionOfficialPersonIds>per50001</ElectionOfficialPersonIds>
+      </ElectionAdministration>
+      <Type>county</Type>
+    </GpUnit>
+    <GpUnit objectId="ru0311" xsi:type="ReportingUnit">
+      <ComposingGpUnitIds>ru_pre90111 ru_pre90139</ComposingGpUnitIds>
+      <ExternalIdentifiers>
+        <ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va/sldl:57</Value>
+        </ExternalIdentifier>
+      </ExternalIdentifiers>
+      <Name>House of Delegates District - 057</Name>
+      <Number>57</Number>
+      <Type>state-house</Type>
+    </GpUnit>
+    <GpUnit objectId="ru0081" xsi:type="ReportingUnit">
+      <ComposingGpUnitIds>ru_pre90139</ComposingGpUnitIds>
+      <ExternalIdentifiers>
+        <ExternalIdentifier>
+          <Type>ocd-id</Type>
+          <Value>ocd-division/country:us/state:va/county:albemarle/council_district:rio</Value>
+        </ExternalIdentifier>
+      </ExternalIdentifiers>
+      <Name>RIO DISTRICT</Name>
+      <Number>1</Number>
+      <Type>county-council</Type>
+    </GpUnit>
+    <GpUnit objectId="ru_preXXXXX" xsi:type="ReportingUnit">
+      <!-- This GpUnit is just here to represent the rest of the state since I
+           didn't feel like including all however many thousand precincts in
+           this one sample file. Real files should not have this and I will
+           find you and yell at you if they do...
+        -->
+      <Name>PLACEHOLDER -- REPRESENTS REST OF STATE OF VIRGINIA</Name>
+      <Type>precinct</Type>
+    </GpUnit>
+    <GpUnit objectId="ru_pre90111" xsi:type="ReportingUnit">
+      <Name>203 - GEORGETOWN</Name>
+      <Number>0203</Number>
+      <Type>precinct</Type>
+    </GpUnit>
+    <GpUnit objectId="ru_pre90139" xsi:type="ReportingUnit">
+      <Name>103 - BRANCHLANDS</Name>
+      <Number>0103</Number>
+      <Type>precinct</Type>
+    </GpUnit>
+    <GpUnit objectId="ru_pre90183" xsi:type="ReportingUnit">
+      <Name>602 - FREE UNION</Name>
+      <Number>0602</Number>
+      <Type>precinct</Type>
+    </GpUnit>
+    <GpUnit objectId="ru_pre92426" xsi:type="ReportingUnit">
+      <ComposingGpUnitIds>ru_temp_id</ComposingGpUnitIds>
+      <Name>304 - EAST IVY</Name>
+      <Number>0304</Number>
+      <Type>precinct</Type>
+    </GpUnit>
+    <GpUnit objectId="ru_temp_id" xsi:type="ReportingUnit">
+      <ComposingGpUnitIds>ru_pre92426</ComposingGpUnitIds>
+      <Name>999 - TEMP</Name>
+      <Number>0999</Number>
+      <Type>precinct</Type>
+    </GpUnit>
+  </GpUnitCollection>
+  <Issuer>Commonwealth of Virginia</Issuer>
+  <IssuerAbbreviation>VA</IssuerAbbreviation>
+  <PersonCollection>
+    <Person objectId="per50001">
+      <ContactInformation label="ci60002">
+        <Email>rwashburne@albemarle.org</Email>
+        <Phone>4349724173</Phone>
+      </ContactInformation>
+      <FirstName>RICHARD</FirstName>
+      <LastName>WASHBURNE</LastName>
+      <MiddleName>J.</MiddleName>
+      <Nickname>JAKE</Nickname>
+      <Title>
+        <Text language="en">General Registrar Physical</Text>
+      </Title>
+    </Person>
+  </PersonCollection>
+  <SequenceStart>1</SequenceStart>
+  <SequenceEnd>1</SequenceEnd>
+  <Status>unofficial-partial</Status>
+  <VendorApplicationId>Hand-Generated v0.1</VendorApplicationId>
+</ElectionReport>


### PR DESCRIPTION
1. Added a new rule GpUnitsTree to ensure that GpUnits in the feed are a tree and don't have cycles.
2. Modified one of the old rules - DuplicateGpUnits to avoid infinite loop due to cycles in GpUnits.
3. Added an XML feed as a test/sample file for rule 'GpUnitsTree'. This feed has GpUnits that are not a tree and form cycles.